### PR TITLE
Feat/card capture

### DIFF
--- a/react-ts-checkout/README.md
+++ b/react-ts-checkout/README.md
@@ -4,6 +4,11 @@
 -   [Node.js](https://nodejs.org)
 -   [TailwindCSS](https://tailwindcss.com/)
 -   [Material UI](https://mui.com/)
+-   [tilled-node](https://www.npmjs.com/package/tilled-node)
+
+You can find documentation for `tilled-node` on
+[docs.tilled.com](https://docs.tilled.com/resources/sdks/tilled-node/) and
+[Github Pages](https://gettilled.github.io/tilled-node/).
 
 # Get started
 

--- a/react-ts-checkout/README.md
+++ b/react-ts-checkout/README.md
@@ -183,7 +183,7 @@ const TilledFieldOptions = {
 };
 ```
 
-## Funtionality
+## Functionality
 
 This hook can be called from inside the component containing the Tilled.js
 fields and uses the `useScript` hook to insert the Tilled.js script into the
@@ -220,7 +220,7 @@ Invoke the hook from inside the component containing your Tilled.js fields:
     [Lifting State Up](https://reactjs.org/docs/lifting-state-up.html) page in
     React's documentation.
 -   By design, Tilled.js inserts iFrames into the DOM for PCI compliance. The
-    values therin **cannot** be accessed by your client-side code. Running the
+    values therein **cannot** be accessed by your client-side code. Running the
     teardown function, as demonstrated in `useTilled` **will** delete the form
     instance and the values stored in its respective iFrames. This will prevent
     duplicate form inputs that could result in difficult to troubleshoot errors.

--- a/react-ts-checkout/client/src/components/Checkout/index.tsx
+++ b/react-ts-checkout/client/src/components/Checkout/index.tsx
@@ -101,7 +101,7 @@ export default function Checkout(props: {
             {errored ? (
                 <Error message={(errorObj as any).message} />
             ) : (
-                <div className='md:grid md:grid-cols-2 md:divide-x divide-slate-400/25'>
+                <div className='lg:grid lg:grid-cols-2 lg:divide-x divide-slate-400/25'>
                     <CartSummary cart={cart} />
                     <ThemeProvider theme={theme}>
                         <PaymentForm

--- a/react-ts-checkout/client/src/components/Checkout/index.tsx
+++ b/react-ts-checkout/client/src/components/Checkout/index.tsx
@@ -101,7 +101,7 @@ export default function Checkout(props: {
             {errored ? (
                 <Error message={(errorObj as any).message} />
             ) : (
-                <div className='grid grid-cols-2 divide-x divide-slate-400/25'>
+                <div className='md:grid md:grid-cols-2 md:divide-x divide-slate-400/25'>
                     <CartSummary cart={cart} />
                     <ThemeProvider theme={theme}>
                         <PaymentForm

--- a/react-ts-checkout/client/src/components/PaymentForm/components/CreditCardFields.tsx
+++ b/react-ts-checkout/client/src/components/PaymentForm/components/CreditCardFields.tsx
@@ -26,6 +26,7 @@ export default function CreditCardFields(props: {
                 '-translate-y-1/2',
             ];
             const openPositioning: Array<string> = ['fixed', 'z-50'];
+
             const handleOpen = () => {
                 openPositioning.forEach(className => {
                     el.classList.add(className);

--- a/react-ts-checkout/client/src/components/PaymentForm/components/CreditCardFields.tsx
+++ b/react-ts-checkout/client/src/components/PaymentForm/components/CreditCardFields.tsx
@@ -73,8 +73,7 @@ export default function CreditCardFields(props: {
             // Reposition the card scan icon when any field is changed
             // Used in place of a success handler
             Object.values(formInstance.fields).forEach((field: any) => {
-                field.on('change', () => {
-                    console.log('field changed');
+                field.on('change', (change: any) => {
                     handleClose(); // repositions the card scan icon
                 });
             });

--- a/react-ts-checkout/client/src/components/PaymentForm/components/CreditCardFields.tsx
+++ b/react-ts-checkout/client/src/components/PaymentForm/components/CreditCardFields.tsx
@@ -14,7 +14,6 @@ export default function CreditCardFields(props: {
     const { account_id, public_key, tilled, options } = props;
 
     const numberInputRef = useRef(null);
-    const cardCaptureRef = useRef(null);
     const expirationInputRef = useRef(null);
     const cvvInputRef = useRef(null);
 
@@ -48,29 +47,28 @@ export default function CreditCardFields(props: {
             formInstance.createField('_cardScanElement').inject(el);
             formInstance.fields._cardScanElement.on('cardscanloaded', () => {
                 el.removeAttribute('hidden');
-
-                if (cancelBtn)
-                    cancelBtn.addEventListener('click', () => {
-                        console.log('cancel button clicked');
-                        handleClose();
-                    });
             });
 
             el.addEventListener('click', () => {
                 handleOpen();
             });
 
-            // Forced to use dom manipulation to get the cancel button inside an iFrame
             formInstance.fields._cardScanElement.on(
                 'cardscanerror',
                 (error: { message: string }) => {
                     //  Silent  fail  for  now  is  fine.  This  should  not  impede  entering  info.
                     console.log('Card  Scan  error:  ' + error?.message);
-                    console.log(error);
+
+                    // You could hide the card scan icon here if you wanted
+                    // el.setAttribute('hidden', 'true');
+
+                    //  Close  the  card  scan  icon  if  it  is  open
                     handleClose();
                 }
             );
 
+            // Reposition the card scan icon when any field is changed
+            // Used in place of a success handler
             Object.values(formInstance.fields).forEach((field: any) => {
                 field.on('change', () => {
                     console.log('field changed');
@@ -87,7 +85,6 @@ export default function CreditCardFields(props: {
             cardExpiry: expirationInputRef,
             cardCvv: cvvInputRef,
         },
-        cardCaptureRef: cardCaptureRef,
         cardCapture,
     };
 

--- a/react-ts-checkout/client/src/components/PaymentForm/components/CreditCardFields.tsx
+++ b/react-ts-checkout/client/src/components/PaymentForm/components/CreditCardFields.tsx
@@ -17,6 +17,7 @@ export default function CreditCardFields(props: {
     const expirationInputRef = useRef(null);
     const cvvInputRef = useRef(null);
 
+    // This feature is still in beta.
     const cardCapture = {
         ref: useRef(null),
         handler: (el: HTMLElement, formInstance: any) => {
@@ -45,6 +46,7 @@ export default function CreditCardFields(props: {
                 });
             };
 
+            // Notice that the _cardScanElement is a private field
             formInstance.createField('_cardScanElement').inject(el);
             formInstance.fields._cardScanElement.on('cardscanloaded', () => {
                 el.removeAttribute('hidden');

--- a/react-ts-checkout/client/src/components/PaymentForm/components/CreditCardFields.tsx
+++ b/react-ts-checkout/client/src/components/PaymentForm/components/CreditCardFields.tsx
@@ -14,6 +14,7 @@ export default function CreditCardFields(props: {
     const { account_id, public_key, tilled, options } = props;
 
     const numberInputRef = useRef(null);
+    const cardCaptureRef = useRef(null);
     const expirationInputRef = useRef(null);
     const cvvInputRef = useRef(null);
 
@@ -24,6 +25,7 @@ export default function CreditCardFields(props: {
             cardExpiry: expirationInputRef,
             cardCvv: cvvInputRef,
         },
+        cardCaptureRef: cardCaptureRef,
     };
 
     const status = useTilled(
@@ -41,6 +43,7 @@ export default function CreditCardFields(props: {
                 id='card-number-element'
                 label='Card Number'
                 inputRef={numberInputRef}
+                cardCaptureRef={cardCaptureRef}
             />
             <Box className='grid grid-cols-2 gap-3 mt-3'>
                 <TilledMuiField

--- a/react-ts-checkout/client/src/components/PaymentForm/components/TilledjsMuiField.tsx
+++ b/react-ts-checkout/client/src/components/PaymentForm/components/TilledjsMuiField.tsx
@@ -8,9 +8,12 @@ export default function TilledMuiField(props: {
     id: string;
     label: string;
     inputRef: React.MutableRefObject<null>;
-    cardCaptureRef?: React.MutableRefObject<null>;
+    cardCapture?: {
+        ref: React.MutableRefObject<null>;
+        handler: (el: HTMLElement, formInstance: any) => void;
+    };
 }) {
-    const { id, label, inputRef, cardCaptureRef } = props;
+    const { id, label, inputRef, cardCapture } = props;
     const elIdPrefix =
         'tilled-mui-field_' + label.replace(' ', '-').toLowerCase();
 
@@ -28,17 +31,17 @@ export default function TilledMuiField(props: {
             >
                 {label}
             </span>
-            {cardCaptureRef ? (
+            {cardCapture ? (
                 <div
                     className='absolute right-2 top-1/2 -translate-y-1/2'
-                    ref={cardCaptureRef}
+                    ref={cardCapture.ref}
                     hidden
                 >
                     <FontAwesomeIcon
                         icon={faCamera}
-                        ref={cardCaptureRef}
                         className='w-6 h-6 text-zinc-600 m-auto'
                     />
+                    {/* <div className='fixed z-50 translate-y-0 top-0 left-0'></div> */}
                 </div>
             ) : (
                 ''

--- a/react-ts-checkout/client/src/components/PaymentForm/components/TilledjsMuiField.tsx
+++ b/react-ts-checkout/client/src/components/PaymentForm/components/TilledjsMuiField.tsx
@@ -21,7 +21,7 @@ export default function TilledMuiField(props: {
         <div id={elIdPrefix + '_container'} className='relative group'>
             <div
                 id={id}
-                className=' outline-0 h-14 hover:border-zinc-500 rounded border border-zinc-300 pt-4 pb-4 pl-3 w-full'
+                className='outline-0 h-14 hover:border-zinc-500 rounded border border-zinc-300 pt-4 pb-4 pl-3 w-full'
                 ref={inputRef}
             />
             {/* <div id="card-brand-icon" /> */}

--- a/react-ts-checkout/client/src/components/PaymentForm/components/TilledjsMuiField.tsx
+++ b/react-ts-checkout/client/src/components/PaymentForm/components/TilledjsMuiField.tsx
@@ -1,11 +1,16 @@
-import { useEffect } from 'react';
+import {
+    FontAwesomeIcon,
+    FontAwesomeIconProps,
+} from '@fortawesome/react-fontawesome';
+import { faCamera } from '@fortawesome/free-solid-svg-icons';
 
 export default function TilledMuiField(props: {
     id: string;
     label: string;
     inputRef: React.MutableRefObject<null>;
+    cardCaptureRef?: React.MutableRefObject<null>;
 }) {
-    const { id, label, inputRef } = props;
+    const { id, label, inputRef, cardCaptureRef } = props;
     const elIdPrefix =
         'tilled-mui-field_' + label.replace(' ', '-').toLowerCase();
 
@@ -21,9 +26,23 @@ export default function TilledMuiField(props: {
                 id={elIdPrefix + '_span'}
                 className='absolute left-0 top-1/2 -translate-y-1/2 text-zinc-600 bg-white ml-2 pl-1 transition-all duration-100 ease-out origin-top-left pointer-events-none'
             >
-                {/* <span className="absolute group-focus-within:text-blue-500 group-focus-within:top-0 group-focus-within:text-xs left-0 top-0 -translate-y-1/2 text-zinc-600 bg-white ml-2 pl-1 transition-all duration-100 ease-out origin-top-left pointer-events-none"> */}
                 {label}
             </span>
+            {cardCaptureRef ? (
+                <div
+                    className='absolute right-2 top-1/2 -translate-y-1/2'
+                    ref={cardCaptureRef}
+                    hidden
+                >
+                    <FontAwesomeIcon
+                        icon={faCamera}
+                        ref={cardCaptureRef}
+                        className='w-6 h-6 text-zinc-600 m-auto'
+                    />
+                </div>
+            ) : (
+                ''
+            )}
         </div>
     );
 }

--- a/react-ts-checkout/client/src/components/PaymentForm/hooks/useTilled.ts
+++ b/react-ts-checkout/client/src/components/PaymentForm/hooks/useTilled.ts
@@ -32,7 +32,7 @@ export default function useTilled(
     tilled: React.MutableRefObject<any>,
     options: ITilledFieldOptions
 ): string {
-    const { fieldOptions, onFocus, onBlur } = options;
+    const { fieldOptions, onFocus, onBlur, onError } = options;
     const { type, fields, cardCapture } = paymentTypeObj;
 
     const form = useRef(null);
@@ -102,12 +102,11 @@ export default function useTilled(
                     if (change.empty === false) onFocus(field)
                 })
             }
-            if (onBlur) {
-                field.on('blur', () => onBlur(field));
-                field.on('change', (change: ChangeEvent) => {
-                    if (change.empty === true) onBlur(field)
-                })
-            }
+            if (onBlur) field.on('blur', () => onBlur(field));
+            field.on('change', (change: ChangeEvent) => console.log(change));
+            if (onError) field.on('change', (change: ChangeEvent) => {
+                if (!change.valid) onError(field);
+            });
         });
 
         // Build the form

--- a/react-ts-checkout/client/src/components/PaymentForm/hooks/useTilled.ts
+++ b/react-ts-checkout/client/src/components/PaymentForm/hooks/useTilled.ts
@@ -102,6 +102,7 @@ export default function useTilled(
                     if (change.empty === false) onFocus(field)
                 })
             }
+            console.log(field)
             if (onBlur) field.on('blur', () => onBlur(field));
             field.on('change', (change: ChangeEvent) => console.log(change));
             if (onError) field.on('change', (change: ChangeEvent) => {

--- a/react-ts-checkout/client/src/components/PaymentForm/hooks/useTilled.ts
+++ b/react-ts-checkout/client/src/components/PaymentForm/hooks/useTilled.ts
@@ -19,14 +19,14 @@ export default function useTilled(
             bankRoutingNumber?: React.MutableRefObject<any>,
             bankAccountNumber?: React.MutableRefObject<any>
         },
-        cardCaptureRef?: React.MutableRefObject<any>,
+        cardCapture?: { ref: React.MutableRefObject<null>; handler: (el: HTMLElement, formInstance: any) => void };
         cardBrandIcon?: React.MutableRefObject<any>
     },
     tilled: React.MutableRefObject<any>,
     options: ITilledFieldOptions
 ): string {
     const { fieldOptions, onFocus, onBlur } = options;
-    const { type, fields, cardCaptureRef } = paymentTypeObj;
+    const { type, fields, cardCapture } = paymentTypeObj;
 
     const form = useRef(null);
 
@@ -77,21 +77,15 @@ export default function useTilled(
                 .inject(fieldElement);
         });
 
-        if (cardCaptureRef) {
-            const cardCaptureEl = cardCaptureRef.current as HTMLElement;
-            formInstance.createField('_cardScanElement').inject(cardCaptureEl);
-            formInstance.fields._cardScanElement.on('cardscanloaded', () => {
-                cardCaptureEl.removeAttribute('hidden');
-            })
-            // cardCaptureEl.addEventListener('click', () => {
-            //     cardCaptureEl.className
-            // });
+        if (cardCapture) {
+            const { ref, handler } = cardCapture;
+            if (ref.current) {
+                const cardCaptureElement = ref.current as HTMLElement;
+                handler(cardCaptureElement, formInstance);
 
-            formInstance.fields._cardScanElement.on('cardscanerror', (error: { message: string; }) => {
-                //  Silent  fail  for  now  is  fine.  This  should  not  impede  entering  info. 
-                console.log('Card  Scan  error:  ' + error?.message);
-                cardCaptureEl.setAttribute('hidden', 'true');
-            });
+            } else {
+                throw new Error('cardCapture ref is not defined');
+            }
         }
 
         Object.values(formInstance.fields).forEach((field: any) => {

--- a/react-ts-checkout/client/src/components/PaymentForm/hooks/useTilled.ts
+++ b/react-ts-checkout/client/src/components/PaymentForm/hooks/useTilled.ts
@@ -19,13 +19,14 @@ export default function useTilled(
             bankRoutingNumber?: React.MutableRefObject<any>,
             bankAccountNumber?: React.MutableRefObject<any>
         },
+        cardCaptureRef?: React.MutableRefObject<any>,
         cardBrandIcon?: React.MutableRefObject<any>
     },
     tilled: React.MutableRefObject<any>,
     options: ITilledFieldOptions
 ): string {
     const { fieldOptions, onFocus, onBlur } = options;
-    const { type, fields } = paymentTypeObj;
+    const { type, fields, cardCaptureRef } = paymentTypeObj;
 
     const form = useRef(null);
 
@@ -75,6 +76,23 @@ export default function useTilled(
                 .createField(field, fieldOptions ? fieldOptions : {})
                 .inject(fieldElement);
         });
+
+        if (cardCaptureRef) {
+            const cardCaptureEl = cardCaptureRef.current as HTMLElement;
+            formInstance.createField('_cardScanElement').inject(cardCaptureEl);
+            formInstance.fields._cardScanElement.on('cardscanloaded', () => {
+                cardCaptureEl.removeAttribute('hidden');
+            })
+            // cardCaptureEl.addEventListener('click', () => {
+            //     cardCaptureEl.className
+            // });
+
+            formInstance.fields._cardScanElement.on('cardscanerror', (error: { message: string; }) => {
+                //  Silent  fail  for  now  is  fine.  This  should  not  impede  entering  info. 
+                console.log('Card  Scan  error:  ' + error?.message);
+                cardCaptureEl.setAttribute('hidden', 'true');
+            });
+        }
 
         Object.values(formInstance.fields).forEach((field: any) => {
             if (onFocus) field.on('focus', () => onFocus(field));

--- a/react-ts-checkout/client/src/components/PaymentForm/hooks/useTilled.ts
+++ b/react-ts-checkout/client/src/components/PaymentForm/hooks/useTilled.ts
@@ -3,6 +3,13 @@ import { ITilledFieldOptions } from '../utils/TilledFieldOptions';
 import useScript from './useScript';
 
 declare global { interface Window { Tilled: any } }
+interface ChangeEvent {
+    valid: boolean,
+    empty: boolean,
+    fieldType: string,
+    error: any,
+    brand: string
+};
 
 // This hook should be called from inside the form field components
 // ach-debit-fields.tsx and credit-card-fields.tsx
@@ -89,8 +96,18 @@ export default function useTilled(
         }
 
         Object.values(formInstance.fields).forEach((field: any) => {
-            if (onFocus) field.on('focus', () => onFocus(field));
-            if (onBlur) field.on('blur', () => onBlur(field));
+            if (onFocus) {
+                field.on('focus', () => onFocus(field));
+                field.on('change', (change: ChangeEvent) => {
+                    if (change.empty === false) onFocus(field)
+                })
+            }
+            if (onBlur) {
+                field.on('blur', () => onBlur(field));
+                field.on('change', (change: ChangeEvent) => {
+                    if (change.empty === true) onBlur(field)
+                })
+            }
         });
 
         // Build the form

--- a/react-ts-checkout/client/src/components/PaymentForm/index.tsx
+++ b/react-ts-checkout/client/src/components/PaymentForm/index.tsx
@@ -234,7 +234,7 @@ function PaymentForm(props: {
                         value='ach_debit'
                     />
                 </Tabs>
-                <Box className='mt-2'>
+                <Box className='mt-2 mb-6'>
                     {type === 'card' ? (
                         <CreditCardFields
                             account_id={account_id}
@@ -253,9 +253,9 @@ function PaymentForm(props: {
                     )}
                 </Box>
                 {customer_id ? (
-                    <Box className='mt-6 text-slate-600'>
+                    <Box className='text-slate-600'>
                         <Controller
-                            defaultValue={false}
+                            defaultValue={subscriptions ? true : false}
                             control={control}
                             name='savePaymentMethod'
                             render={({ field }) => (
@@ -266,6 +266,12 @@ function PaymentForm(props: {
                                             <Switch
                                                 color='primary'
                                                 {...field}
+                                                disabled={
+                                                    subscriptions ? true : false
+                                                }
+                                                defaultChecked={
+                                                    subscriptions ? true : false
+                                                }
                                             />
                                         }
                                         label='Save this payment method?'

--- a/react-ts-checkout/client/src/components/PaymentForm/index.tsx
+++ b/react-ts-checkout/client/src/components/PaymentForm/index.tsx
@@ -73,16 +73,8 @@ function PaymentForm(props: {
         let tilledParams: {
             payment_method?: string;
         };
-        const {
-            name,
-            street,
-            country,
-            state,
-            city,
-            zip,
-            account_type,
-            savePaymentMethod,
-        } = data;
+        const { name, street, country, state, city, zip, account_type } = data;
+        let { savePaymentMethod } = data; // Will force true if subscriptions are present
         const billing_details = {
             name,
             address: {
@@ -93,6 +85,10 @@ function PaymentForm(props: {
                 zip,
             },
         };
+
+        // Force true if subscriptions are present
+        // Subscriptions require a payment method to be attached to a customer
+        if (subscriptions) data.savePaymentMethod = true;
 
         if (paymentMethodId.current) {
             console.log(
@@ -114,8 +110,6 @@ function PaymentForm(props: {
                     account_type,
                     account_holder_name: name.slice(0, 22),
                 };
-            console.log(paymentMethodParams);
-            console.log(tilledInstance);
 
             paymentMethodParams.ach_debit = newPM =
                 await tilledInstance.createPaymentMethod(paymentMethodParams);

--- a/react-ts-checkout/client/src/components/PaymentForm/index.tsx
+++ b/react-ts-checkout/client/src/components/PaymentForm/index.tsx
@@ -73,8 +73,16 @@ function PaymentForm(props: {
         let tilledParams: {
             payment_method?: string;
         };
-        const { name, street, country, state, city, zip, account_type } = data;
-        let { savePaymentMethod } = data; // Will force true if subscriptions are present
+        const {
+            name,
+            street,
+            country,
+            state,
+            city,
+            zip,
+            account_type,
+            savePaymentMethod,
+        } = data;
         const billing_details = {
             name,
             address: {
@@ -85,10 +93,6 @@ function PaymentForm(props: {
                 zip,
             },
         };
-
-        // Force true if subscriptions are present
-        // Subscriptions require a payment method to be attached to a customer
-        if (subscriptions) data.savePaymentMethod = true;
 
         if (paymentMethodId.current) {
             console.log(

--- a/react-ts-checkout/client/src/components/PaymentForm/utils/TilledFieldOptions.ts
+++ b/react-ts-checkout/client/src/components/PaymentForm/utils/TilledFieldOptions.ts
@@ -7,7 +7,7 @@ export interface ITilledFieldOptions {
 
 const baseStyles = {
     element: ['outline-0', 'h-14', 'rounded', 'pt-4', 'pb-4', 'pl-3', 'w-full'],
-    label: ['absolute', 'left-0', '-translate-y-1/2', 'bg-white', 'ml-2', 'pl-1', 'transition-all', 'duration-100', 'ease-out', 'origin-top-left', 'pointer-events-none'],
+    label: ['bg-white', 'absolute', 'origin-top-left', 'left-0', 'transition-all', 'pointer-events-none', '-translate-y-1/2', 'ml-2', 'pl-1', 'duration-100', 'ease-out'],
 }
 const blurStyles = {
     element: ['border-zinc-300', 'border', 'hover:border-zinc-500'],
@@ -26,17 +26,17 @@ const emptyStyles = {
 };
 
 const applyBaseStyles = (element: Element, label: Element | null) => {
-    element.classList.forEach(cl => {
-        element.classList.remove(cl)
-    });
+    // element.classList.forEach(cl => {
+    //     console.log(cl)
+    //     element.classList.remove(cl)
+    //     console.log('element.classList', element.classList)
+    // });
+    element.className = baseStyles.element.join(' ');
     element.classList.add(...baseStyles.element);
 
-    if (label) {
-        label.classList.forEach(cl => {
-            label.classList.remove(cl)
-        })
-        label.classList.add(...baseStyles.label);
-    }
+
+    if (label) label.className = baseStyles.label.join(' ');
+    label?.classList.add(...baseStyles.label);
 };
 
 
@@ -61,52 +61,39 @@ export const TilledFieldOptions = {
             },
         },
     },
-    onFocus(field: { element: Element }) {
-        const element = field.element;
+    onFocus(field: { element: Element, valid: boolean }) {
+        const { element, valid } = field;
         const label = element.nextElementSibling;
 
         applyBaseStyles(element, label);
 
-        element.classList.add(...focusStyles.element);
-        label?.classList.add(...focusStyles.label);
-        // element.classList.add('border-slate-700');
-        // element.classList.add('border-2');
-        // label?.classList.add('text-slate-700');
-        // label?.classList.add('top-0');
-        // label?.classList.add('text-xs');
-
-        // element.classList.remove('border-zinc-300');
-        // element.classList.remove('border');
-        // element.classList.remove('hover:border-zinc-500');
-        // label?.classList.remove('text-zinc-600');
-        // label?.classList.remove('top-1/2');
+        if (valid) {
+            element.classList.add(...focusStyles.element);
+            label?.classList.add(...focusStyles.label);
+        } else {
+            element.classList.add(...errorStyles.element);
+            label?.classList.add(...errorStyles.label);
+        }
     },
-    onBlur(field: { element: Element, empty: boolean }) {
-        const { element, empty } = field;
+    onBlur(field: { element: Element, empty: boolean, valid: boolean }) {
+        const { element, empty, valid } = field;
         const label = element.nextElementSibling;
 
         applyBaseStyles(element, label);
-        element.classList.add(...blurStyles.element);
-        label?.classList.add(...blurStyles.label);
-
-        if (empty) {
-            label?.classList.add(...emptyStyles.label);
+        if (valid) {
+            element.classList.add(...blurStyles.element);
+            label?.classList.add(...blurStyles.label);
+        } else {
+            element.classList.add(...errorStyles.element);
+            label?.classList.add(...errorStyles.label);
         }
 
-        // element.classList.add('border-zinc-300');
-        // element.classList.add('border');
-        // element.classList.add('hover:border-zinc-500');
-        // label?.classList.add('text-zinc-600');
-
-        // element.classList.remove('border-slate-700');
-        // element.classList.remove('border-2');
-        // label?.classList.remove('text-slate-700');
-
-        // if (empty) {
-        //     label?.classList.add('top-1/2');
-        //     label?.classList.remove('top-0');
-        //     label?.classList.remove('text-xs');
-        // }
+        if (empty) {
+            label?.classList.remove('text-xs');
+            label?.classList.add(...emptyStyles.label);
+        } else {
+            label?.classList.add('top-0', 'text-xs');
+        }
     },
     onError(field: { element: Element }) {
         const element = field.element;
@@ -115,17 +102,5 @@ export const TilledFieldOptions = {
         applyBaseStyles(element, label);
         element.classList.add(...errorStyles.element);
         label?.classList.add(...errorStyles.label);
-
-        // element.classList.add('border-red-500');
-        // element.classList.add('border-2');
-        // label?.classList.add('text-red-500');
-        // label?.classList.add('top-0');
-        // label?.classList.add('text-xs');
-
-        // element.classList.remove('border-slate-700');
-        // element.classList.remove('border-2');
-        // label?.classList.remove('text-slate-700');
-        // label?.classList.remove('top-0');
-        // label?.classList.remove('text-xs');
     }
 };

--- a/react-ts-checkout/client/src/components/PaymentForm/utils/TilledFieldOptions.ts
+++ b/react-ts-checkout/client/src/components/PaymentForm/utils/TilledFieldOptions.ts
@@ -1,8 +1,44 @@
 export interface ITilledFieldOptions {
     fieldOptions?: { styles?: { base?: { fontFamily?: string, color?: string, fontWeight?: string, fontSize?: string } } };
-    onFocus(field: { element: Element }): void;
-    onBlur(field: { element: Element, empty: boolean }): void;
+    onFocus?(field: { element: Element }): void;
+    onBlur?(field: { element: Element, empty: boolean }): void;
+    onError?(field: { element: Element }): void;
 }
+
+const baseStyles = {
+    element: ['outline-0', 'h-14', 'rounded', 'pt-4', 'pb-4', 'pl-3', 'w-full'],
+    label: ['absolute', 'left-0', '-translate-y-1/2', 'bg-white', 'ml-2', 'pl-1', 'transition-all', 'duration-100', 'ease-out', 'origin-top-left', 'pointer-events-none'],
+}
+const blurStyles = {
+    element: ['border-zinc-300', 'border', 'hover:border-zinc-500'],
+    label: ['text-zinc-600'],
+};
+const focusStyles = {
+    element: ['border-slate-700', 'border-2'],
+    label: ['text-slate-700', 'top-0', 'text-xs'],
+};
+const errorStyles = {
+    element: ['border-red-500', 'border-2'],
+    label: ['text-red-500', 'top-0', 'text-xs'],
+};
+const emptyStyles = {
+    label: ['top-1/2'],
+};
+
+const applyBaseStyles = (element: Element, label: Element | null) => {
+    element.classList.forEach(cl => {
+        element.classList.remove(cl)
+    });
+    element.classList.add(...baseStyles.element);
+
+    if (label) {
+        label.classList.forEach(cl => {
+            label.classList.remove(cl)
+        })
+        label.classList.add(...baseStyles.label);
+    }
+};
+
 
 export const TilledFieldOptions = {
     fieldOptions: {
@@ -29,35 +65,67 @@ export const TilledFieldOptions = {
         const element = field.element;
         const label = element.nextElementSibling;
 
-        element.classList.add('border-slate-700');
-        element.classList.add('border-2');
-        label?.classList.add('text-slate-700');
-        label?.classList.add('top-0');
-        label?.classList.add('text-xs');
+        applyBaseStyles(element, label);
 
-        element.classList.remove('border-zinc-300');
-        element.classList.remove('border');
-        element.classList.remove('hover:border-zinc-500');
-        label?.classList.remove('text-zinc-600');
-        label?.classList.remove('top-1/2');
+        element.classList.add(...focusStyles.element);
+        label?.classList.add(...focusStyles.label);
+        // element.classList.add('border-slate-700');
+        // element.classList.add('border-2');
+        // label?.classList.add('text-slate-700');
+        // label?.classList.add('top-0');
+        // label?.classList.add('text-xs');
+
+        // element.classList.remove('border-zinc-300');
+        // element.classList.remove('border');
+        // element.classList.remove('hover:border-zinc-500');
+        // label?.classList.remove('text-zinc-600');
+        // label?.classList.remove('top-1/2');
     },
     onBlur(field: { element: Element, empty: boolean }) {
         const { element, empty } = field;
         const label = element.nextElementSibling;
 
-        element.classList.add('border-zinc-300');
-        element.classList.add('border');
-        element.classList.add('hover:border-zinc-500');
-        label?.classList.add('text-zinc-600');
-
-        element.classList.remove('border-slate-700');
-        element.classList.remove('border-2');
-        label?.classList.remove('text-slate-700');
+        applyBaseStyles(element, label);
+        element.classList.add(...blurStyles.element);
+        label?.classList.add(...blurStyles.label);
 
         if (empty) {
-            label?.classList.add('top-1/2');
-            label?.classList.remove('top-0');
-            label?.classList.remove('text-xs');
+            label?.classList.add(...emptyStyles.label);
         }
+
+        // element.classList.add('border-zinc-300');
+        // element.classList.add('border');
+        // element.classList.add('hover:border-zinc-500');
+        // label?.classList.add('text-zinc-600');
+
+        // element.classList.remove('border-slate-700');
+        // element.classList.remove('border-2');
+        // label?.classList.remove('text-slate-700');
+
+        // if (empty) {
+        //     label?.classList.add('top-1/2');
+        //     label?.classList.remove('top-0');
+        //     label?.classList.remove('text-xs');
+        // }
     },
+    onError(field: { element: Element }) {
+        const element = field.element;
+        const label = element.nextElementSibling;
+
+        applyBaseStyles(element, label);
+        element.classList.add(...errorStyles.element);
+        label?.classList.add(...errorStyles.label);
+
+        // element.classList.add('border-red-500');
+        // element.classList.add('border-2');
+        // label?.classList.add('text-red-500');
+        // label?.classList.add('top-0');
+        // label?.classList.add('text-xs');
+
+        // element.classList.remove('border-slate-700');
+        // element.classList.remove('border-2');
+        // label?.classList.remove('text-slate-700');
+        // label?.classList.remove('top-0');
+        // label?.classList.remove('text-xs');
+    }
 };


### PR DESCRIPTION
No rush on this one. 

This PR does a few things in addition to adding card capture.
- fixes a bug in subscriptions. If a cart contains a subscription, it disables the the save payment method and defaults it to true. This is necessary since subscriptions require a payment method that is attached to a customer. 
- adds mobile responsiveness by using a tailwind modifier to make the cart summary and payment forms "stack" unless the screen is large enough to fit them side by side (1024px)
- adds error styling for tilled.js fields