### PR TITLE
Fix/return duplicate pm

### DIFF
--- a/react-ts-checkout/client/src/components/PaymentForm/hooks/useTilled.ts
+++ b/react-ts-checkout/client/src/components/PaymentForm/hooks/useTilled.ts
@@ -102,9 +102,7 @@ export default function useTilled(
                     if (change.empty === false) onFocus(field)
                 })
             }
-            console.log(field)
             if (onBlur) field.on('blur', () => onBlur(field));
-            field.on('change', (change: ChangeEvent) => console.log(change));
             if (onError) field.on('change', (change: ChangeEvent) => {
                 if (!change.valid) onError(field);
             });

--- a/react-ts-checkout/client/src/components/PaymentForm/index.tsx
+++ b/react-ts-checkout/client/src/components/PaymentForm/index.tsx
@@ -142,7 +142,6 @@ function PaymentForm(props: {
 
             if (response.status === 201) {
                 const pm = await response.json();
-                console.log(pm);
                 console.log('using saved pm', pm);
                 tilledParams = { payment_method: pm.id };
             } else {

--- a/react-ts-checkout/client/src/components/PaymentForm/index.tsx
+++ b/react-ts-checkout/client/src/components/PaymentForm/index.tsx
@@ -139,7 +139,15 @@ function PaymentForm(props: {
                     }),
                 }
             );
-            console.log(response);
+
+            if (response.status === 201) {
+                const pm = await response.json();
+                console.log(pm);
+                console.log('using saved pm', pm);
+                tilledParams = { payment_method: pm.id };
+            } else {
+                console.log(response);
+            }
         }
 
         if (paymentIntent) {


### PR DESCRIPTION
 I am trying to handle an error by checking if the error message is `The card associated with this PaymentMethod is already associated with this customer on another PaymentMethod.`. If it is: 
 - I make a request to the get a payment method endpoint to get that PM’s card object and the list all payment methods endpoint.
 - Then I loop through all the payment methods and  check for equality with the card object. If it matches I return the already attached PM. Note that this solution requires 2 additional api requests.
 - I return the PM with a status of 201 Redirected instead of a 200

In the client, I check to see if the response status is 201 and replace the entered PM.id with the saved PM.id returned by the attach endpoint