### PR TITLE
Update sample .env values to match code

### DIFF
--- a/react-ts-checkout/README.md
+++ b/react-ts-checkout/README.md
@@ -35,7 +35,7 @@ TILLED_SECRET_KEY=sk_XXXX
 
 ```
 VITE_TILLED_PUBLIC_KEY=pk_XXXX
-VITE_TILLED_ACCOUNT_ID=acct_XXXX
+VITE_TILLED_MERCHANT_ACCOUNT_ID=acct_XXXX
 VITE_TILLED_CUSTOMER_ID=cus_XXXX // needed if you want to save and use saved payment methods
 VITE_TILLED_MERCHANT_NAME=Merchant's Name // use your merchant's name in the checkout summary
 VITE_TILLED_MERCHANT_TAX = 1.08 // add the sales tax for your merchant


### PR DESCRIPTION
The env variable for tilled account ID suggested in the readme does not match what is being referenced in code.

See these two files:
https://github.com/gettilled/tilled-example-monorepo/blob/master/react-ts-checkout/client/src/components/Checkout/index.tsx#L40
https://github.com/gettilled/tilled-example-monorepo/blob/master/react-ts-checkout/client/src/components/PaymentForm/index.tsx#L29